### PR TITLE
Shell script improvements

### DIFF
--- a/mdb2sqlite.sh
+++ b/mdb2sqlite.sh
@@ -4,6 +4,7 @@
 # https://www.codeenigma.com/community/blog/using-mdbtools-nix-convert-microsoft-access-mysql
 
 # USAGE
+# Make sure "mdbtools" is installed
 # Rename your MDB file to migration-export.mdb 
 # run ./mdb2sqlite.sh migration-export.mdb
 # wait and wait a bit longer...
@@ -15,17 +16,22 @@ sql=${fname/mdb/sqlite}
 schema=${fname/mdb/schema}
 dir=${fname/.mdb/}-$now
 
+# Create temporary directory for exported tables
 mkdir $dir
 
+# Export database schema from mdb file
 mdb-schema $fname sqlite > $dir/$schema
 
+# Export each table in mdb file to temporary sql file
 for i in $( mdb-tables $fname ); do 
   echo $i  
-  mdb-export -D "%Y-%m-%d %H:%M:%S" -H -I sqlite $fname $i > $dir/$i.sql
+  mdb-export -D "%Y-%m-%d %H:%M:%S" -H -q "'" -I sqlite $fname $i > $dir/$i.sql
 done
 
+# Create destination sqlite database based on previously exported schema
 < $dir/$schema $sqlite $sql
 
+# Insert values from temporary exported tables into destination database
 for f in $dir/*.sql ; do 
   echo $f 
   (echo 'BEGIN;'; cat $f; echo 'COMMIT;') | $sqlite $sql


### PR DESCRIPTION
Adds comments to shell script
Sets quote character to single quote when exporting tables using mdb_export. Double quotes, which are default, are not accepted by sqlite3.